### PR TITLE
Add flatpak/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Flatpak
+/builddir
+/build-dir
+/repo
+/.flatpak-builder

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Learn to play the piano at your own pace through various modes of practice. [Wat
 - [x] Interactive fifths practice
 - [x] Interactive quiz
 - [x] Hard mode
+- [x] Shuffle mode
 
 ## Coming Soon
 

--- a/flatpak/com.zaaane.pianotrainer.metainfo.xml
+++ b/flatpak/com.zaaane.pianotrainer.metainfo.xml
@@ -12,8 +12,9 @@
     <p>
       The app also includes a couple of extra options:
     </p>
-    <p>
-      - Ping Pong mode: A mode where users play scales forwards, then backwards. - Hard mode: A mode that hides the next note in the scale until the user gets it correct. - Shuffle mode: Switch to a new scale after completing the current one.
+    <p><em>Ping Pong mode</em>: A mode where users play scales forwards, then backwards.
+      <em>Hard mode</em>: A mode that hides the next note in the scale until the user gets it correct.
+      <em>Shuffle mode</em>: Switch to a new scale after completing the current one.
     </p>
     <p>
       Piano Trainer has built-in piano sounds and support for multiple languages (English, French, Japanese, German, Portuguese, and Chinese.) The app is cross-platform and open-sourced.

--- a/flatpak/com.zaaane.pianotrainer.metainfo.xml
+++ b/flatpak/com.zaaane.pianotrainer.metainfo.xml
@@ -3,19 +3,25 @@
   <id>com.zaaane.pianotrainer</id>
   <name>Piano Trainer</name>
   <summary>Memorize piano scales with ease! A piano practice program w/ MIDI support. Consider it an interactive reference manual 🎹</summary>
+  <developer id="com.zaaane">
+    <name>Zane Helton</name>
+  </developer>
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
+  <url type="homepage">https://zaneh.itch.io/piano-trainer</url>
+  <url type="vcs-browser">https://github.com/ZaneH/piano-trainer</url>
+  <url type="bugtracker">https://github.com/ZaneH/piano-trainer/issues</url>
   <description>
-    <p>
-      Piano Trainer is an app designed to help users learn basic piano scales and chords at their own pace using a MIDI or QWERTY keyboard. The app offers two modes: Quiz and Practice. In Quiz mode, users can test their knowledge of the circle of fifths and key recognition. Practice mode allows users to work on scales, chords, and fifths with interactive exercises and feedback.
+    <p><em>Piano Trainer</em> is an app designed to help users learn basic piano scales and chords at their own pace using a MIDI or QWERTY keyboard. The app offers two modes: Quiz and Practice. In Quiz mode, users can test their knowledge of the circle of fifths and key recognition. Practice mode allows users to work on scales, chords, and fifths with interactive exercises and feedback.
     </p>
     <p>
-      The app also includes a couple of extra options:
+      The app includes:
     </p>
-    <p><em>Ping Pong mode</em>: A mode where users play scales forwards, then backwards.
-      <em>Hard mode</em>: A mode that hides the next note in the scale until the user gets it correct.
-      <em>Shuffle mode</em>: Switch to a new scale after completing the current one.
-    </p>
+    <ul>
+      <li><em>Ping Pong mode</em>: A mode where users play scales forwards, then backwards.</li>
+      <li><em>Hard mode</em>: A mode that hides the next note in the scale until the user gets it correct.</li>
+      <li><em>Shuffle mode</em>: Switch to a new scale after completing the current one.</li>
+    </ul>
     <p>
       Piano Trainer has built-in piano sounds and support for multiple languages (English, French, Japanese, German, Portuguese, and Chinese.) The app is cross-platform and open-sourced.
     </p>
@@ -23,10 +29,18 @@
   <launchable type="desktop-id">com.zaaane.pianotrainer.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://i.imgur.com/Nxg1706.png</image>
+      <image>https://zaaane.com/piano-trainer/main-screen.png</image>
+      <caption>Practice all of your scales</caption>
     </screenshot>
     <screenshot>
-      <image>https://i.imgur.com/mBg1fjH.png</image>
+      <image>https://zaaane.com/piano-trainer/quiz-mode.png</image>
+      <caption>Quiz mode tests your knowledge</caption>
     </screenshot>
   </screenshots>
+  <releases>
+    <release version="1.3.1" date="2025-07-09"/>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">intense</content_attribute>
+  </content_rating>
 </component>

--- a/flatpak/com.zaaane.pianotrainer.yaml
+++ b/flatpak/com.zaaane.pianotrainer.yaml
@@ -3,7 +3,7 @@
 id: com.zaaane.pianotrainer
 
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 
 command: piano-trainer

--- a/flatpak/com.zaaane.pianotrainer.yaml
+++ b/flatpak/com.zaaane.pianotrainer.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=wayland # Permission needed to show the window
   - --socket=fallback-x11 # Permission needed to show the window
   - --socket=pulseaudio # Access to PulseAudio, input/output, MIDI
+  - --device=dri # OpenGL, not necessary for all projects
   - --share=ipc
   - --share=network
   - --env=WEBKIT_DISABLE_COMPOSITING_MODE=1 # Optional: may solve some issues with black webviews on Wayland

--- a/flatpak/com.zaaane.pianotrainer.yaml
+++ b/flatpak/com.zaaane.pianotrainer.yaml
@@ -21,10 +21,11 @@ modules:
 
     sources:
       - type: file
-        path: flatpak.metainfo.xml
+        path: com.zaaane.pianotrainer.metainfo.xml
       - type: file
-        # Update version here
-        path: ../src-tauri/target/release/bundle/deb/Piano Trainer_1.3.1_amd64.deb
+        url: https://github.com/ZaneH/piano-trainer/releases/download/app-v1.3.1/Piano.Trainer_1.3.1_amd64.deb
+        sha256: 9f125bc25364a15ab4b669e3dfab53da64bc761498b5efdd7cd30979081fc728
+        only-arches: [x86_64]
     build-commands:
       - set -e
 
@@ -45,4 +46,4 @@ modules:
       - install -Dm644 deb-extract/usr/share/icons/hicolor/128x128/apps/Piano\ Trainer.png /app/share/icons/hicolor/128x128/apps/com.zaaane.pianotrainer.png
       - install -Dm644 deb-extract/usr/share/icons/hicolor/32x32/apps/Piano\ Trainer.png /app/share/icons/hicolor/32x32/apps/com.zaaane.pianotrainer.png
       - install -Dm644 deb-extract/usr/share/icons/hicolor/256x256@2/apps/Piano\ Trainer.png /app/share/icons/hicolor/256x256@2/apps/com.zaaane.pianotrainer.png
-      - install -Dm644 flatpak.metainfo.xml /app/share/metainfo/com.zaaane.pianotrainer.metainfo.xml
+      - install -Dm644 com.zaaane.pianotrainer.metainfo.xml /app/share/metainfo/com.zaaane.pianotrainer.metainfo.xml

--- a/flatpak/flatpak-builder.yaml
+++ b/flatpak/flatpak-builder.yaml
@@ -1,0 +1,48 @@
+# https://v2.tauri.app/distribute/flatpak/
+# This Flatpak builder configuration was taken from the Tauri docs.
+id: com.zaaane.pianotrainer
+
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+
+command: piano-trainer
+finish-args:
+  - --socket=wayland # Permission needed to show the window
+  - --socket=fallback-x11 # Permission needed to show the window
+  - --socket=pulseaudio # Access to PulseAudio, input/output, MIDI
+  - --share=ipc
+  - --share=network
+  - --env=WEBKIT_DISABLE_COMPOSITING_MODE=1 # Optional: may solve some issues with black webviews on Wayland
+
+modules:
+  - name: binary
+    buildsystem: simple
+
+    sources:
+      - type: file
+        path: flatpak.metainfo.xml
+      - type: file
+        # Update version here
+        path: ../src-tauri/target/release/bundle/deb/Piano Trainer_1.3.1_amd64.deb
+    build-commands:
+      - set -e
+
+      # Extract the deb package
+      - mkdir deb-extract
+      - ar -x *.deb --output deb-extract
+      - tar -C deb-extract -xf deb-extract/data.tar.gz
+
+      # Copy binary
+      - mkdir -p /app/bin
+      - 'install -Dm755 deb-extract/usr/bin/Piano\ Trainer /app/bin/piano-trainer'
+
+      # Copy desktop file + ensure the right icon is set
+      - sed -i 's/^Icon=.*/Icon=com.zaaane.pianotrainer/' deb-extract/usr/share/applications/Piano\ Trainer.desktop
+      - install -Dm644 deb-extract/usr/share/applications/Piano\ Trainer.desktop /app/share/applications/com.zaaane.pianotrainer.desktop
+
+      # Copy icons
+      - install -Dm644 deb-extract/usr/share/icons/hicolor/128x128/apps/Piano\ Trainer.png /app/share/icons/hicolor/128x128/apps/com.zaaane.pianotrainer.png
+      - install -Dm644 deb-extract/usr/share/icons/hicolor/32x32/apps/Piano\ Trainer.png /app/share/icons/hicolor/32x32/apps/com.zaaane.pianotrainer.png
+      - install -Dm644 deb-extract/usr/share/icons/hicolor/256x256@2/apps/Piano\ Trainer.png /app/share/icons/hicolor/256x256@2/apps/com.zaaane.pianotrainer.png
+      - install -Dm644 flatpak.metainfo.xml /app/share/metainfo/com.zaaane.pianotrainer.metainfo.xml

--- a/flatpak/flatpak.metainfo.xml
+++ b/flatpak/flatpak.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.zaaane.pianotrainer</id>
+  <name>Piano Trainer</name>
+  <summary>Memorize piano scales with ease! A piano practice program w/ MIDI support. Consider it an interactive reference manual 🎹</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      Piano Trainer is an app designed to help users learn basic piano scales and chords at their own pace using a MIDI or QWERTY keyboard. The app offers two modes: Quiz and Practice. In Quiz mode, users can test their knowledge of the circle of fifths and key recognition. Practice mode allows users to work on scales, chords, and fifths with interactive exercises and feedback.
+    </p>
+    <p>
+      The app also includes a couple of extra options:
+    </p>
+    <p>
+      - Ping Pong mode: A mode where users play scales forwards, then backwards. - Hard mode: A mode that hides the next note in the scale until the user gets it correct. - Shuffle mode: Switch to a new scale after completing the current one.
+    </p>
+    <p>
+      Piano Trainer has built-in piano sounds and support for multiple languages (English, French, Japanese, German, Portuguese, and Chinese.) The app is cross-platform and open-sourced.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.zaaane.pianotrainer.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://i.imgur.com/Nxg1706.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://i.imgur.com/mBg1fjH.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   "productName": "Piano Trainer",
   "mainBinaryName": "Piano Trainer",
   "version": "1.3.1",
-  "identifier": "com.zane.piano-trainer",
+  "identifier": "com.zaaane.pianotrainer",
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI5ODJFNDA4ODM4NkY4QjAKUldTdytJYURDT1NDS1FZV0lUS3doQURibmtaRGZqUzJxUmI3UzBXY0JxK1drcCtNLy92bUpEaVoK",
@@ -72,6 +72,6 @@
       "digestAlgorithm": "sha256",
       "timestampUrl": ""
     },
-    "createUpdaterArtifacts": "v1Compatible"
+    "createUpdaterArtifacts": false
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,8 +7,8 @@
     "frontendDist": "../build"
   },
   "productName": "Piano Trainer",
-  "mainBinaryName": "Piano Trainer",
-  "version": "1.3.1",
+  "mainBinaryName": "piano-trainer",
+  "version": "1.3.2",
   "identifier": "com.zaaane.pianotrainer",
   "plugins": {
     "updater": {


### PR DESCRIPTION
## What changed?

- Add `flatpak/` folder with configuration
    - Version is hard coded
- Changed app ID (`com.zane.piano-trainer` -> `com.zaaane.pianotrainer`)

See also: #37

## How was this tested?

- Set `bundle.targets` to `deb`
- Run `pnpm run tauri build`
- Built, installed, and ran with:
```
$ flatpak-builder --force-clean --user --repo=repo --install builddir flatpak/com.zaaane.pianotrainer.yaml
$ flatpak run com.zaaane.pianotrainer
```

## Additional context

- Using [Tauri's Flathub guide](https://v2.tauri.app/distribute/flatpak/) for reference