### PR TITLE
Update flatpak source sha256 checksum and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ $ yarn tauri build
 
 ## Build and Install Flatpak
 
-For non-FHS distros, the Flatpak can be used as a self-contained runtime environment. After cloning the repo, you can
-use the following commands to install and run Piano Trainer using Flatpak.
+For non-FHS distros, the Flatpak can be used as a self-contained runtime environment. Ensure these build dependencies are installed: `flatpak`, `flatpak-builder`, and `appstream`. After cloning the repo, use the following commands to install and run Piano Trainer:
 
 ```bash
 $ flatpak-builder --force-clean --user --install-deps-from=flathub --install builddir flatpak/com.zane.piano-trainer.yaml

--- a/flatpak/com.zane.piano-trainer.yaml
+++ b/flatpak/com.zane.piano-trainer.yaml
@@ -6,6 +6,10 @@ runtime: org.gnome.Platform
 runtime-version: '48'
 sdk: org.gnome.Sdk
 
+build-options:
+  build-args:
+    - --share=network
+
 command: piano-trainer
 finish-args:
   - --socket=wayland # Permission needed to show the window
@@ -26,7 +30,7 @@ modules:
       - type: file
         # NOTE This needs to be updated with each release
         url: https://github.com/ZaneH/piano-trainer/releases/download/app-v1.3.2/Piano.Trainer_1.3.2_amd64.deb
-        sha256: f9eef1591ee8128afd02b059fd754ce2ee057afb1bc6ff8f94efe2fd202eb03f
+        sha256: db68d57c5e84327511dde0e24c397a24c85bd74a110eab8771839cdd044ece7a
         only-arches: [x86_64]
     build-commands:
       - set -e


### PR DESCRIPTION
Mentioned dependencies needed for `flatpak-builder` in `README.md` and fixed sha256 checksum error:
````
~/piano-trainer  main [?1]  v22.16.0 
22:58:58 ❯ flatpak-builder --force-clean --user --install-deps-from=flathub --install builddir flatpak/com.zane.piano-trainer.yaml
log
Dependency Sdk: org.gnome.Sdk 48
Updating org.gnome.Sdk/x86_64/48

Nothing to do.
Dependency Runtime: org.gnome.Platform 48
Updating org.gnome.Platform/x86_64/48

Nothing to do.
Emptying app dir 'builddir'
Downloading sources
Downloading https://github.com/ZaneH/piano-trainer/releases/download/app-v1.3.2/Piano.Trainer_1.3.2_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 7168k  100 7168k    0     0  12.8M      0 --:--:-- --:--:-- --:--:-- 12.8M
Failed to download sources: module piano-trainer: Wrong sha256 checksum for Piano.Trainer_1.3.2_amd64.deb, expected "f9eef1591ee8128afd02b059fd754ce2ee057afb1bc6ff8f94efe2fd202eb03f", was "db68d57c5e84327511dde0e24c397a24c85bd74a110eab8771839cdd044ece7a"

````